### PR TITLE
Allow making requests without CORS headers

### DIFF
--- a/browser_extension/manifest.json
+++ b/browser_extension/manifest.json
@@ -16,5 +16,11 @@
     "persistent": true
   },
   "browser_action": {},
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
+  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+  "content_scripts":[{
+      "all_frames": false,
+      "matches":["*://*/"],
+      "js":["background.js"],
+      "run_at": "document_end"
+  }]
 }


### PR DESCRIPTION
This trick is taken from elasticsearch-head, works fine with Chrome but not Firefox, I think the missing part is [Content-Security-Policy directive](https://github.com/mobz/elasticsearch-head/blob/master/src/chrome_ext/manifest.json#L12) with the script hash which I wasn't able to make work properly.

By the way, awesome project, elasticsearch badly needs a decent UI and this looks promising!