### PR TITLE
Adding type prefix for query_string search

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -27,7 +27,8 @@ export const DEFAULT_SEARCH_PARAMS = {
   from: 0,
   size: 1000,
   _source: '',
-  index: ''
+  index: '',
+  query_type: 'phrase_prefix'
 }
 
 export const REQUEST_DEFAULT_HEADERS = {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -2,7 +2,7 @@ import { DEFAULT_SEARCH_PARAMS } from '../consts'
 
 export function normalizeSearchParams (params) {
   const search = {}
-  search.query = { query_string: { query: params.q || DEFAULT_SEARCH_PARAMS.q } }
+  search.query = { query_string: { query: params.q || DEFAULT_SEARCH_PARAMS.q, type: DEFAULT_SEARCH_PARAMS.query_type } }
   search.index = params.index || DEFAULT_SEARCH_PARAMS.index
   if (params.sort) {
     search.sort = [{}]

--- a/tests/unit/helpers/normalizeSearchParams.spec.js
+++ b/tests/unit/helpers/normalizeSearchParams.spec.js
@@ -4,7 +4,7 @@ import { DEFAULT_SEARCH_PARAMS } from '@/consts'
 describe('helpers/normalizeSearchParams', () => {
   it('has correct default values', () => {
     expect(normalizeSearchParams({})).toEqual({
-      query: { query_string: { query: '*' } },
+      query: { query_string: { query: '*', type: DEFAULT_SEARCH_PARAMS.query_type } },
       from: 0,
       size: 1000,
       index: ''
@@ -14,7 +14,7 @@ describe('helpers/normalizeSearchParams', () => {
   it('normalizes correctly when some params are missing', () => {
     const params = { q: 'query', size: '3' }
     const expected = {
-      query: { query_string: { query: 'query' } },
+      query: { query_string: { query: 'query', type: DEFAULT_SEARCH_PARAMS.query_type } },
       from: DEFAULT_SEARCH_PARAMS.from,
       size: 3,
       index: DEFAULT_SEARCH_PARAMS.index
@@ -31,7 +31,7 @@ describe('helpers/normalizeSearchParams', () => {
       index: 'myIndex'
     }
     const expected = {
-      query: { query_string: { query: 'query' } },
+      query: { query_string: { query: 'query', type: DEFAULT_SEARCH_PARAMS.query_type } },
       from: 5,
       size: 20,
       _source: ['col1'],
@@ -49,7 +49,7 @@ describe('helpers/normalizeSearchParams', () => {
       index: 'myIndex'
     }
     const expected = {
-      query: { query_string: { query: 'query' } },
+      query: { query_string: { query: 'query', type: DEFAULT_SEARCH_PARAMS.query_type } },
       from: 5,
       size: 20,
       index: 'myIndex'


### PR DESCRIPTION
Since searching is using standard analyzer which analyzes the word "client's" for instance as it is, hence searching with key word "client" will return missing results.
`phrase_prefix` will cover this case.