### PR TITLE
fix: reset results after failed search

### DIFF
--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -130,6 +130,7 @@
           const val = parseJsonBigInt(searchQuery.value)
           callElasticsearch('search', val, indices.value)
             .then(result => (searchResults.value = result))
+            .catch(() => (searchResults.value = {}))
         } catch (e) {
           queryParsingError.value = true
         }


### PR DESCRIPTION
This fixes an issue on the search page when using a custom search.
After sending a request with a bad query, a second correct request will not display any results.

Without resetting the results in the catch block, the previous data in searchResult contains kind of bad data as the entries there are missing the _source attribute. This results in a null pointer exception in the renameForbiddenObjectKeys helper function which leads to not displaying actual available results.

![custom_search_error](https://user-images.githubusercontent.com/22787373/129392644-ac71bd7e-ffb9-4c7e-abdc-6dbf59916735.gif)
