### PR TITLE
Added arm64 support for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,12 @@ WORKDIR /usr/src/app
 COPY package.json .
 COPY yarn.lock .
 
-RUN yarn install
+RUN apk add --no-cache --virtual .gyp python make g++
+
+RUN yarn install --ignore-optional
+
+RUN apk del .gyp
+
 COPY . .
 RUN yarn build
 

--- a/package.json
+++ b/package.json
@@ -48,13 +48,15 @@
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-vue": "^7.10.0",
     "eslint-plugin-vuetify": "^1.0.1",
-    "puppeteer": "^10.1.0",
     "sass": "^1.37.2",
     "sass-loader": "^10.1.1",
     "vue-cli-plugin-i18n": "~2.1.1",
     "vue-jest": "^3.0.7",
     "vue-template-compiler": "^2.6.14",
     "worker-loader": "^3.0.8"
+  },
+  "optionalDependencies": {
+    "puppeteer": "^10.1.0"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
So the main problem is package called puppeteer. I made this one optional. I also added missing packages for builder in docker file.

As far as I know this image should be built using buildx not build command