### PR TITLE
Add favicon

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,17 +1,25 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>elasticvue</title>
-</head>
-<body>
-<noscript>
-  <strong>We're sorry but new-elasticvue doesn't work properly without JavaScript enabled. Please enable it to
-    continue.</strong>
-</noscript>
-<div id="app"></div>
-<!-- built files will be auto injected -->
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <link
+      rel="shortcut icon"
+      type="image/png"
+      href="/images/logo/manifest/blue_16.png"
+      sizes="16x16"
+    />
+    <title>elasticvue</title>
+  </head>
+  <body>
+    <noscript>
+      <strong
+        >We're sorry but new-elasticvue doesn't work properly without JavaScript
+        enabled. Please enable it to continue.</strong
+      >
+    </noscript>
+    <div id="app"></div>
+    <!-- built files will be auto injected -->
+  </body>
 </html>


### PR DESCRIPTION
I've been using the Firefox extension a lot recently and unfortunately I have a habit of leaving way too many tabs open. Adding a favicon to the tab that the extension opens would help me find it more quickly. Hopefully it would help others as well

![image](https://user-images.githubusercontent.com/42785777/147888628-3099b2ce-8bf8-4a1f-a179-228a0d2328e9.png)
