### PR TITLE
fix json format for AWS OpenSearch

### DIFF
--- a/src/services/ElasticsearchAdapter.js
+++ b/src/services/ElasticsearchAdapter.js
@@ -28,10 +28,12 @@ export default class ElasticsearchAdapter {
   }
 
   catIndices (params, filter) {
+    params.format = 'json'
     return this.client.catIndices(params, filter)
   }
 
   catShards (params, filter) {
+    params.format = 'json'
     return this.client.catShards(params, filter)
   }
 
@@ -96,6 +98,7 @@ export default class ElasticsearchAdapter {
   }
 
   catNodes (params) {
+    params.format = 'json'
     return this.client.catNodes(params)
   }
 


### PR DESCRIPTION
By using AWS OpenSearch, some APIs (like `/_cat/indices`) don't return in json format, even if `accept="application/json"` are set.

So I need to add `format=json` to get json format.