### PR TITLE
Selecting highlighs is not prominent in the light theme

### DIFF
--- a/src/assets/stylesheets/theme/variables.css
+++ b/src/assets/stylesheets/theme/variables.css
@@ -24,7 +24,7 @@
   --code-editor-gutter-background: #f0f0f0;
   --code-editor-gutter-color: #333;
   --code-editor-gutter-border-color: #f0f0f0;
-  --code-editor-active-line-background: #ddd;
+  --code-editor-active-line-background: #cceeff44;
   --code-editor-search-selected-background: #555;
   --code-editor-button-background: var(--theme-dark-grey-background);
   --code-editor-button-hover-background: #535353;


### PR DESCRIPTION
Before：
<img width="750" alt="image" src="https://github.com/cars10/elasticvue/assets/26108404/f60da857-0422-4cff-9268-199ca62066c6">

After:
<img width="760" alt="image" src="https://github.com/cars10/elasticvue/assets/26108404/17979edc-6e51-4446-b967-e43f4d72ca4f">

In the dark theme, is all ok:
<img width="759" alt="image" src="https://github.com/cars10/elasticvue/assets/26108404/0852c91c-1e00-4024-a21a-4afd5fe66b2a">
