### PR TITLE
feat: Migrate preferred queries

### DIFF
--- a/src/composables/CallElasticsearch.ts
+++ b/src/composables/CallElasticsearch.ts
@@ -41,7 +41,7 @@ export function useElasticsearchAdapter () {
         const cluster = connectionStore.activeCluster
         if (!cluster) return
         elasticsearchAdapter = new ElasticsearchAdapter(cluster as ElasticsearchClusterCredentials)
-        await elasticsearchAdapter.ping()
+        // await elasticsearchAdapter.ping()
       }
 
       try {

--- a/src/composables/components/home/ClusterHealth.ts
+++ b/src/composables/components/home/ClusterHealth.ts
@@ -1,13 +1,11 @@
 import { ElasticsearchCluster, ElasticsearchClusterCredentials, useConnectionStore } from '../../../store/connection.ts'
 import ElasticsearchAdapter from '../../../services/ElasticsearchAdapter.ts'
-import { clusterUuid } from '../../ClusterConnection.ts'
 
 export const useClusterHealth = () => {
   const connectionStore = useConnectionStore()
 
   const setupHealthLoading = () => {
     if (!connectionStore.activeCluster) return
-    checkHealth(connectionStore.activeCluster)
     //setInterval(() => (checkHealth(connectionStore.activeCluster)), 30000)
   }
   setupHealthLoading()
@@ -27,15 +25,6 @@ export const checkHealth = async (cluster: ElasticsearchCluster) => {
     const clusterHealthResponse: any = await adapter.clusterHealth()
     const clusterHealthBody = await clusterHealthResponse.json()
     cluster.status = clusterHealthBody.status
-
-    const pingResponse: any = await adapter.ping()
-    const pingBody = await pingResponse.json()
-    const version = pingBody.version.number
-
-    cluster.clusterName = pingBody.cluster_name
-    cluster.version = version
-    cluster.majorVersion = version[0]
-    if (!cluster.uuid || cluster.uuid.length === 0) cluster.uuid = clusterUuid(pingBody)
 
     delete cluster.loading
   } catch (e) {

--- a/src/db/Idb.ts
+++ b/src/db/Idb.ts
@@ -11,7 +11,7 @@ const dbDefinition = {
   ]
 }
 
-const databaseName = (clusterUuid: string) => (`elasticvue-${clusterUuid}`)
+const databaseName = (clusterUuid?: string) => (`elasticvue${clusterUuid ? '-' + clusterUuid : ''}`)
 
 let db: Db
 export const useIdb = () => {
@@ -25,7 +25,7 @@ export const useIdb = () => {
   return db
 }
 
-export const initDb = (clusterUuid: string) => {
+export const initDb = (clusterUuid?: string) => {
   db = new Db({ dbName: databaseName(clusterUuid), ...dbDefinition })
   db.connect()
   db.models.restQueryHistory = new DbModel<IdbRestQueryHistory>('restQueryHistory', db)
@@ -36,3 +36,14 @@ export const initDb = (clusterUuid: string) => {
 }
 
 export const useIdbStore = () => (useIdb()?.models)
+export const useOldIdbStore = async () => {
+  const instance = new Db({
+    dbName: databaseName(), dbVersion: 1, tables: [
+      { name: 'rest', indexes: ['date', 'favorite'] }
+    ]
+  });
+  await instance.connect();
+
+  instance.models.restQuerySavedQueries = new DbModel<IdbRestQuerySavedQuery>('rest', instance)
+  return instance.models;
+}

--- a/src/db/indexeddb.ts
+++ b/src/db/indexeddb.ts
@@ -112,6 +112,11 @@ export class DbModel<T> {
     return this.db._idb.getAll(this.tableName)
   }
 
+  async getAllByCriteria (criteria: IDBKeyRange): Promise<T[]> {
+    await this.db.connect()
+    return this.db._idb.getAll(this.tableName, criteria)
+  }
+
   async clear () {
     await this.db.connect()
     return this.db._idb?.clear(this.tableName)

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -18,6 +18,7 @@ export type IdbRestQuerySavedQuery = {
   method: string
   path: string
   body: string
+  favorite?: 1 | 0
 }
 
 export type IdbRestQueryTab = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,10 +10,12 @@ import './assets/stylesheets/style.scss'
 import { migrate } from './services/VuexMigrator.ts'
 
 migrate()
-const myApp = createApp(App)
+.finally(() => {
+    const myApp = createApp(App)
 
-myApp.use(Quasar, quasarOptions)
-myApp.use(pinia)
-myApp.use(vueI18n())
-myApp.use(router)
-myApp.mount('#app')
+    myApp.use(Quasar, quasarOptions)
+    myApp.use(pinia)
+    myApp.use(vueI18n())
+    myApp.use(router)
+    myApp.mount('#app')
+})

--- a/tests/unit/migration.spec.ts
+++ b/tests/unit/migration.spec.ts
@@ -1,5 +1,6 @@
-import { describe, it } from 'vitest'
+import { describe, it, vi } from 'vitest'
 import { migrateVuexData } from '../../src/services/VuexMigrator'
+import ElasticsearchAdapter from '../../src/services/ElasticsearchAdapter'
 
 const vuexData = {
   'connection': {
@@ -35,7 +36,7 @@ const newData = {
       'clusterName': '',
       'version': '6.8.2',
       'majorVersion': '6',
-      'uuid': '',
+      'uuid': 'D_qHru2wRbSM6kZwsP853Q',
       'status': ''
     },
       {
@@ -46,7 +47,7 @@ const newData = {
         'clusterName': '',
         'version': '8.7.1',
         'majorVersion': '8',
-        'uuid': '',
+        'uuid': 'D_qHru2wRbSM6kZwsP853Q',
         'status': ''
       }],
     'activeClusterIndex': 0
@@ -61,7 +62,13 @@ const newData = {
 
 describe.concurrent('migrate vuex', () => {
   it('migrate', async ({ expect }) => {
+    // Given
     const data = JSON.stringify(vuexData)
-    expect(migrateVuexData(data)).toEqual(newData)
+
+    // When
+    vi.spyOn(ElasticsearchAdapter.prototype, 'ping').mockResolvedValue({ json: () => ({ cluster_uuid: 'D_qHru2wRbSM6kZwsP853Q' }) });
+
+    // Then
+    expect(migrateVuexData(data)).resolves.toStrictEqual(newData)
   })
 })


### PR DESCRIPTION
To ensure a smooth transition from elasticvue < 1 to elasticvue >= 1, this pull request fixes #200 by migrating the instances to the new IDB scheme used by elasticvue.