### PR TITLE
Update RestQueryForm.ts

### DIFF
--- a/src/composables/components/rest/RestQueryForm.ts
+++ b/src/composables/components/rest/RestQueryForm.ts
@@ -46,6 +46,8 @@ export const useRestQueryForm = (props: RestQueryFormProps, emit: any) => {
     }
 
     let url = connectionStore.activeCluster.uri
+
+    if (url.endsWith('/')) url = url.slice(0, -1)
     if (!props.tab.request.path.startsWith('/')) url += '/'
     url += props.tab.request.path
 


### PR DESCRIPTION
Remove trailing forward slash from active cluster's uri

In case of active cluster uri having trailing forward slash, all requests sent have doubled slash in url, resulting in failed queries