### PR TITLE
Fix CPU bar not shown in Nodes table if cpu=0%

### DIFF
--- a/src/components/nodes/NodesTable.vue
+++ b/src/components/nodes/NodesTable.vue
@@ -35,7 +35,7 @@
           <span v-if="row.load_1m">{{ row.load_1m }} / {{ row.load_5m }} / {{ row.load_15m }}</span>
         </td>
         <td>
-          <div v-if="row.cpu">
+          <div v-if="!isNaN(row.cpu)">
             {{ row.cpu }}%
             <node-percent-progress :value="row.cpu" class="q-mt-xs" />
           </div>


### PR DESCRIPTION
If the current CPU usage of a node is 0%, the nodes table doesn't show the CPU usage percent and "progress" bar.

Before:

![Screenshot_20240424-232406](https://github.com/cars10/elasticvue/assets/535234/c6ca3bb6-2edf-42b3-8df2-c3143e971f6e)

After:

![Screenshot_20240425-003413](https://github.com/cars10/elasticvue/assets/535234/168e6d71-6e74-4200-aa67-627d182c8e1d)
