### PR TITLE
#294 Changed the Default Search Query (as "query" : "*" don't work if…

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -24,7 +24,7 @@ export const DEFAULT_HIDE_INDICES_REGEX = '^\\..*'
 export const DEFAULT_HIDE_NODE_ATTRIBUTES_REGEX = '^(ml|xpack|transform)\\.'
 export const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
 
-export const DEFAULT_SEARCH_QUERY_OBJ = { query: { query_string: { query: '*' } }, size: 10, from: 0, sort: [] }
+export const DEFAULT_SEARCH_QUERY_OBJ = { query: { match_all: {} }, size: 10, from: 0, sort: [] }
 export const DEFAULT_SEARCH_QUERY = JSON.stringify(DEFAULT_SEARCH_QUERY_OBJ)
 export const DEFAULT_SEARCH_RESULT_COLUMNS = ['_index', '_type', '_id', '_score']
 export const DEFAULT_SORTABLE_COLUMNS = ['_index', '_type', '_id', '_score']


### PR DESCRIPTION
This query is being used to fetch the document for a given index (without any filter), but the problem with this query is that if in index's setting, the default field is set to something and if that field doesn't exists in that doc, it will not show up in the search result because of this right now I am unable to see any doc in one index and some docs are not visible in other indices.