### PR TITLE
feat: add support for aws profile alongside basic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elasticvue",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "elasticvue",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.2",
         "@intlify/unplugin-vue-i18n": "^4.0.0",
@@ -185,7 +185,6 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -228,7 +227,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
       "integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.4.0",
@@ -251,7 +249,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.1.tgz",
       "integrity": "sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -277,7 +274,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
       "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.37.0",
@@ -289,7 +285,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
       "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -299,7 +294,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.15.tgz",
       "integrity": "sha512-aCWjgweIIXLBHh7bY6cACvXuyrZ0xGafjQ2VInjp4RM4gMfscK5uESiNdrH0pE+e1lZr2B4ONGsjchl2KsKZzg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -347,7 +341,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -388,7 +381,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1897,7 +1889,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1911,7 +1902,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1925,7 +1915,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1939,7 +1928,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1953,7 +1941,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1967,7 +1954,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1981,7 +1967,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1995,7 +1980,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2009,7 +1993,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2023,7 +2006,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2037,7 +2019,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2051,7 +2032,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2065,7 +2045,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2079,7 +2058,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2093,7 +2071,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2107,7 +2084,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2121,7 +2097,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2135,7 +2110,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2149,7 +2123,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2163,7 +2136,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2177,7 +2149,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2191,7 +2162,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2205,7 +2175,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2219,7 +2188,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2233,7 +2201,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2630,7 +2597,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -2861,7 +2827,6 @@
       "integrity": "sha512-uM5iXipgYIn13UUQCZNdWkYk+sysBeA97d5mHsAoAt1u/wpN3+zxOmsVJWosuzX+IMGRzeYUNytztrYznboIkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rolldown/pluginutils": "1.0.0-rc.2"
       },
@@ -3249,7 +3214,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3998,7 +3962,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4122,7 +4085,6 @@
       "integrity": "sha512-f1J/tcbnrpgC8suPN5AtdJ5MQjuXbSU9pGRSSYAuF3SHoiYCOdEX6O22pLaRyLHXvDcOe+O5ENgc1owQ587agA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
@@ -4523,7 +4485,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5657,7 +5618,6 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -5761,7 +5721,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5804,7 +5763,6 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -5916,7 +5874,6 @@
       "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.18.6.tgz",
       "integrity": "sha512-ZlK+vJXOBPSFDCNQDBDNwSI+AHoqaFPxK8ve6mhsYLhMKWI5b8zsGY9VU1xYjngO2aBvU4fvGWXy4tTbzrBk8Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.18.1",
         "npm": ">= 6.13.4",
@@ -6013,7 +5970,6 @@
       "integrity": "sha512-wbT0mBmWbIvvq8NeEYWWvevvxnOyhKChir47S66WCxw1SXqhw7ssIYejnQEVt7XYQpsj2y8F9PM+Cr3SNEa0gw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6123,7 +6079,6 @@
       "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -6411,7 +6366,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.1.1",
         "@csstools/css-parser-algorithms": "^4.0.0",
@@ -6856,7 +6810,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7024,7 +6977,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7218,7 +7170,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.28.tgz",
       "integrity": "sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.28",
         "@vue/compiler-sfc": "3.5.28",
@@ -7241,7 +7192,6 @@
       "integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0 || ^9.0.0",
@@ -7278,7 +7228,6 @@
       "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.2.8.tgz",
       "integrity": "sha512-vJ123v/PXCZntd6Qj5Jumy7UBmIuE92VrtdX+AXr+1WzdBHojiBxnAxdfctUFL+/JIN+VQH4BhsfTtiGsvVObg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@intlify/core-base": "11.2.8",
         "@intlify/shared": "11.2.8",
@@ -7653,7 +7602,6 @@
       "resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.3.2.tgz",
       "integrity": "sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.0.0",
         "yaml": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elasticvue",
   "private": true,
-  "version": "1.14.0",
+  "version": "1.15.0",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -579,6 +579,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "configparser"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,11 +816,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -825,7 +852,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -927,6 +954,8 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 name = "elasticvue"
 version = "0.1.0"
 dependencies = [
+ "configparser",
+ "dirs 5.0.1",
  "env_logger",
  "fetch_reqwest",
  "path-clean",
@@ -3433,6 +3462,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4317,7 +4357,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4367,7 +4407,7 @@ checksum = "ca7bd893329425df750813e95bd2b643d5369d929438da96d5bbb7cc2c918f74"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4533,7 +4573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fe8e9bebd88fc222938ffdfbdcfa0307081423bd01e3252fc337d8bde81fc61"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -5025,7 +5065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -5777,6 +5817,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5824,6 +5873,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5885,6 +5949,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5903,6 +5973,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5918,6 +5994,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5951,6 +6033,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5966,6 +6054,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5987,6 +6081,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6002,6 +6102,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6165,7 +6271,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dpi",
  "dunce",
  "gdkx11",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,8 @@ tauri = { version = "2", features = [] }
 #fetch_reqwest = { path = '../../../rust/fetch_reqwest' }
 fetch_reqwest = { git = "https://github.com/cars10/fetch_reqwest" }
 path-clean = "1"
+dirs = "5"
+configparser = "3"
 env_logger = "0.11.3"
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/src/aws_profile.rs
+++ b/src-tauri/src/aws_profile.rs
@@ -1,0 +1,295 @@
+use configparser::ini::Ini;
+use serde::Serialize;
+use std::env;
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedAwsCredentials {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_token: Option<String>,
+    pub region: String,
+}
+
+fn aws_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".aws"))
+}
+
+fn credentials_path() -> Option<PathBuf> {
+    aws_dir().map(|d| d.join("credentials"))
+}
+
+fn config_path() -> Option<PathBuf> {
+    aws_dir().map(|d| d.join("config"))
+}
+
+fn credentials_section(profile_name: &str) -> &str {
+    if profile_name.is_empty() {
+        "default"
+    } else {
+        profile_name
+    }
+}
+
+fn config_section(profile_name: &str) -> String {
+    if profile_name.is_empty() || profile_name == "default" {
+        "default".to_string()
+    } else {
+        format!("profile {}", profile_name)
+    }
+}
+
+fn credentials_from_env(region_override: Option<&str>) -> Option<ResolvedAwsCredentials> {
+    let access_key_id = env::var("AWS_ACCESS_KEY_ID").ok()?;
+    let secret_access_key = env::var("AWS_SECRET_ACCESS_KEY").ok()?;
+    if access_key_id.trim().is_empty() || secret_access_key.trim().is_empty() {
+        return None;
+    }
+    let session_token = env::var("AWS_SESSION_TOKEN").ok();
+    let region = region_override
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(|| env::var("AWS_REGION").ok())
+        .or_else(|| env::var("AWS_DEFAULT_REGION").ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())?;
+    Some(ResolvedAwsCredentials {
+        access_key_id: access_key_id.trim().to_string(),
+        secret_access_key: secret_access_key.trim().to_string(),
+        session_token: session_token.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()),
+        region,
+    })
+}
+
+fn resolve_aws_profile_inner(
+    profile_name: String,
+    region: Option<String>,
+) -> Result<ResolvedAwsCredentials, String> {
+    resolve_aws_profile_with_paths(profile_name, region, credentials_path(), config_path())
+}
+
+fn resolve_aws_profile_with_paths(
+    profile_name: String,
+    region: Option<String>,
+    credentials_path: Option<PathBuf>,
+    config_path: Option<PathBuf>,
+) -> Result<ResolvedAwsCredentials, String> {
+    let profile = if profile_name.is_empty() {
+        "default"
+    } else {
+        profile_name.as_str()
+    };
+    let region_override = region.as_deref();
+
+    let creds_path = credentials_path.ok_or("Could not resolve home directory")?;
+    if !creds_path.exists() {
+        if let Some(creds) = credentials_from_env(region_override) {
+            return Ok(creds);
+        }
+        return Err(format!(
+            "AWS credentials file not found: {}. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY or create the file.",
+            creds_path.display()
+        ));
+    }
+
+    let mut creds_ini = Ini::new();
+    if let Err(e) = creds_ini.load(&creds_path) {
+        if let Some(creds) = credentials_from_env(region_override) {
+            return Ok(creds);
+        }
+        return Err(format!("Failed to parse credentials file: {}", e));
+    }
+
+    let section = credentials_section(profile);
+    let access_key_id = match creds_ini.get(section, "aws_access_key_id") {
+        Some(v) if !v.trim().is_empty() => v,
+        _ => {
+            if let Some(creds) = credentials_from_env(region_override) {
+                return Ok(creds);
+            }
+            return Err(format!(
+                "Profile [{}] not found or missing aws_access_key_id. Check the profile name or set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY.",
+                section
+            ));
+        }
+    };
+    let secret_access_key = match creds_ini.get(section, "aws_secret_access_key") {
+        Some(v) if !v.trim().is_empty() => v,
+        _ => {
+            if let Some(creds) = credentials_from_env(region_override) {
+                return Ok(creds);
+            }
+            return Err(format!(
+                "Profile [{}] not found or missing aws_secret_access_key. Check the profile name or set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY.",
+                section
+            ));
+        }
+    };
+    let session_token = creds_ini.get(section, "aws_session_token");
+
+    // Resolve region in order of precedence:
+    // 1. Region passed from the UI (Profile tab)
+    // 2. Region in the credentials file section
+    // 3. Region in ~/.aws/config for the matching profile
+    let region = match region {
+        Some(r) if !r.trim().is_empty() => r.trim().to_string(),
+        _ => {
+            if let Some(r) = creds_ini.get(section, "region") {
+                r.trim().to_string()
+            } else if let Some(config_path) = &config_path {
+                if config_path.exists() {
+                    let mut config_ini = Ini::new();
+                    if let Ok(_) = config_ini.load(config_path) {
+                        let config_section = config_section(profile);
+                        if let Some(r) = config_ini.get(&config_section, "region") {
+                            r.trim().to_string()
+                        } else {
+                            return Err("Region is required (set in form, credentials file, or ~/.aws/config)".to_string());
+                        }
+                    } else {
+                        return Err("Failed to parse ~/.aws/config while resolving region".to_string());
+                    }
+                } else {
+                    return Err("Region is required (set in form, credentials file, or ~/.aws/config)".to_string());
+                }
+            } else {
+                return Err("Region is required (set in form, credentials file, or ~/.aws/config)".to_string());
+            }
+        }
+    };
+
+    Ok(ResolvedAwsCredentials {
+        access_key_id: access_key_id.trim().to_string(),
+        secret_access_key: secret_access_key.trim().to_string(),
+        session_token: session_token.map(|s| s.trim().to_string()),
+        region,
+    })
+}
+
+#[tauri::command]
+pub async fn resolve_aws_profile(
+    profile_name: String,
+    region: Option<String>,
+) -> Result<ResolvedAwsCredentials, String> {
+    resolve_aws_profile_inner(profile_name, region)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::{Mutex, OnceLock};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        old_value: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: Option<&str>) -> Self {
+            let old_value = env::var(key).ok();
+            match value {
+                Some(v) => env::set_var(key, v),
+                None => env::remove_var(key),
+            }
+            Self { key, old_value }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(old_value) = &self.old_value {
+                env::set_var(self.key, old_value);
+            } else {
+                env::remove_var(self.key);
+            }
+        }
+    }
+
+    fn write_credentials_file(file_content: &str) -> PathBuf {
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let dir = env::temp_dir().join(format!("elasticvue-aws-profile-test-{}", ts));
+        fs::create_dir_all(&dir).expect("failed to create test directory");
+        let credentials = dir.join("credentials");
+        fs::write(&credentials, file_content)
+            .expect("failed to write test credentials file");
+        credentials
+    }
+
+    #[test]
+    fn falls_back_to_env_when_profile_missing_access_key() {
+        let _env_lock = env_lock().lock().expect("env lock poisoned");
+        let credentials_path = write_credentials_file("[default]\naws_secret_access_key=PROFILE_SECRET\n");
+        let _access_key_guard = EnvVarGuard::set("AWS_ACCESS_KEY_ID", Some("ENV_ACCESS"));
+        let _secret_key_guard = EnvVarGuard::set("AWS_SECRET_ACCESS_KEY", Some("ENV_SECRET"));
+        let _session_token_guard = EnvVarGuard::set("AWS_SESSION_TOKEN", Some("ENV_TOKEN"));
+        let _region_guard = EnvVarGuard::set("AWS_REGION", Some("eu-central-1"));
+        let _default_region_guard = EnvVarGuard::set("AWS_DEFAULT_REGION", None);
+
+        let resolved = resolve_aws_profile_with_paths(
+            "default".to_string(),
+            None,
+            Some(credentials_path),
+            None,
+        )
+        .expect("should resolve from env");
+        assert_eq!(resolved.access_key_id, "ENV_ACCESS");
+        assert_eq!(resolved.secret_access_key, "ENV_SECRET");
+        assert_eq!(resolved.session_token.as_deref(), Some("ENV_TOKEN"));
+        assert_eq!(resolved.region, "eu-central-1");
+    }
+
+    #[test]
+    fn falls_back_to_env_when_profile_missing_secret_key() {
+        let _env_lock = env_lock().lock().expect("env lock poisoned");
+        let credentials_path = write_credentials_file("[default]\naws_access_key_id=PROFILE_ACCESS\n");
+        let _access_key_guard = EnvVarGuard::set("AWS_ACCESS_KEY_ID", Some("ENV_ACCESS"));
+        let _secret_key_guard = EnvVarGuard::set("AWS_SECRET_ACCESS_KEY", Some("ENV_SECRET"));
+        let _session_token_guard = EnvVarGuard::set("AWS_SESSION_TOKEN", Some("ENV_TOKEN"));
+        let _region_guard = EnvVarGuard::set("AWS_REGION", Some("eu-central-1"));
+        let _default_region_guard = EnvVarGuard::set("AWS_DEFAULT_REGION", None);
+
+        let resolved = resolve_aws_profile_with_paths(
+            "default".to_string(),
+            None,
+            Some(credentials_path),
+            None,
+        )
+        .expect("should resolve from env");
+        assert_eq!(resolved.access_key_id, "ENV_ACCESS");
+        assert_eq!(resolved.secret_access_key, "ENV_SECRET");
+        assert_eq!(resolved.session_token.as_deref(), Some("ENV_TOKEN"));
+        assert_eq!(resolved.region, "eu-central-1");
+    }
+
+    #[test]
+    fn returns_error_for_incomplete_profile_without_env() {
+        let _env_lock = env_lock().lock().expect("env lock poisoned");
+        let credentials_path = write_credentials_file("[default]\naws_access_key_id=PROFILE_ACCESS\n");
+        let _access_key_guard = EnvVarGuard::set("AWS_ACCESS_KEY_ID", None);
+        let _secret_key_guard = EnvVarGuard::set("AWS_SECRET_ACCESS_KEY", None);
+        let _session_token_guard = EnvVarGuard::set("AWS_SESSION_TOKEN", None);
+        let _region_guard = EnvVarGuard::set("AWS_REGION", None);
+        let _default_region_guard = EnvVarGuard::set("AWS_DEFAULT_REGION", None);
+
+        let err = resolve_aws_profile_with_paths(
+            "default".to_string(),
+            None,
+            Some(credentials_path),
+            None,
+        )
+        .expect_err("should fail");
+        assert!(err.contains("aws_secret_access_key"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 use fetch_reqwest::{FetchOptions, FetchResponseResult};
 
+mod aws_profile;
 mod load_file;
 mod menu;
 mod save_file;
@@ -37,7 +38,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             fetch_reqwest,
             load_file,
-            save_file
+            save_file,
+            aws_profile::resolve_aws_profile
         ])
         .run(ctx)
         .expect("error while running tauri application");

--- a/src/components/setup/ClusterFormFields.vue
+++ b/src/components/setup/ClusterFormFields.vue
@@ -67,37 +67,67 @@
     </div>
 
     <div v-if="cluster.auth.authType === AuthType.awsIAM">
-      <custom-input
-        v-model="cluster.auth.authData.accessKeyId"
-        autocomplete="off"
+      <q-select
+        v-model="awsCredentialType"
+        :options="awsCredentialTypeOptions"
+        :label="t('setup.test_and_connect.form.aws_credential_type.label')"
+        emit-value
+        map-options
         outlined
-        :rules="[required]"
-        :label="t('setup.test_and_connect.form.access_key_id.label')"
+        options-dense
         class="q-mb-md"
+        data-testid="aws-credential-type"
       />
-      <custom-input
-        v-model="cluster.auth.authData.secretAccessKey"
-        autocomplete="off"
-        outlined
-        :rules="[required]"
-        :label="t('setup.test_and_connect.form.secret_access_key.label')"
-        class="q-mb-md"
-      />
-      <custom-input
-        v-model="cluster.auth.authData.region"
-        autocomplete="off"
-        outlined
-        :rules="[required]"
-        :label="t('setup.test_and_connect.form.region.label')"
-        class="q-mb-md"
-      />
-      <custom-input
-        v-model="cluster.auth.authData.sessionToken"
-        autocomplete="off"
-        outlined
-        :label="t('setup.test_and_connect.form.session_token.label')"
-        class="q-mb-md"
-      />
+      <template v-if="isAwsBasic && awsBasicAuthData">
+        <custom-input
+          v-model="awsBasicAuthData.accessKeyId"
+          autocomplete="off"
+          outlined
+          :rules="[required]"
+          :label="t('setup.test_and_connect.form.access_key_id.label')"
+          class="q-mb-md"
+        />
+        <custom-input
+          v-model="awsBasicAuthData.secretAccessKey"
+          autocomplete="off"
+          outlined
+          :rules="[required]"
+          :label="t('setup.test_and_connect.form.secret_access_key.label')"
+          class="q-mb-md"
+        />
+        <custom-input
+          v-model="awsBasicAuthData.region"
+          autocomplete="off"
+          outlined
+          :rules="[required]"
+          :label="t('setup.test_and_connect.form.region.label')"
+          class="q-mb-md"
+        />
+        <custom-input
+          v-model="awsBasicAuthData.sessionToken"
+          autocomplete="off"
+          outlined
+          :label="t('setup.test_and_connect.form.session_token.label')"
+          class="q-mb-md"
+        />
+      </template>
+      <template v-else-if="isAwsProfile && awsProfileAuthData">
+        <custom-input
+          v-model="awsProfileAuthData.profileName"
+          autocomplete="off"
+          outlined
+          :rules="[required]"
+          :label="t('setup.test_and_connect.form.profile_name.label')"
+          class="q-mb-md"
+        />
+        <custom-input
+          v-model="awsProfileAuthData.region"
+          autocomplete="off"
+          outlined
+          :label="t('setup.test_and_connect.form.region_optional.label')"
+          class="q-mb-md"
+        />
+      </template>
     </div>
 
     <custom-input
@@ -130,7 +160,7 @@
 import { computed, ref, watch } from 'vue'
 import { useTranslation } from '../../composables/i18n.ts'
 import { DEFAULT_CLUSTER_URI } from '../../consts.ts'
-import { AuthType, ElasticsearchClusterConnection } from '../../store/connection.ts'
+import { AuthType, ElasticsearchClusterConnection, getAwsCredentialType, type AwsCredentialType } from '../../store/connection.ts'
 import { buildConfig } from '../../buildConfig.ts'
 import CustomInput from '../shared/CustomInput.vue'
 
@@ -144,9 +174,66 @@ const authorizationTypes = [
 ]
 
 const cluster = ref(props.modelValue)
+const t = useTranslation()
+
+const awsCredentialTypeOptions = computed<{ value: AwsCredentialType; label: string }[]>(() => [
+  { value: 'basic', label: t('setup.test_and_connect.form.aws_credential_type.basic') },
+  { value: 'profile', label: t('setup.test_and_connect.form.aws_credential_type.profile') }
+])
+
+const isAwsBasic = computed(() => {
+  if (cluster.value.auth.authType !== AuthType.awsIAM) return false
+  return getAwsCredentialType(cluster.value.auth) !== 'profile'
+})
+
+const isAwsProfile = computed(() => getAwsCredentialType(cluster.value.auth) === 'profile')
+
+const awsBasicAuthData = computed(() => {
+  if (cluster.value.auth.authType !== AuthType.awsIAM) return null
+  const d = cluster.value.auth.authData as {
+    awsCredentialType?: string
+    accessKeyId?: string
+    secretAccessKey?: string
+    sessionToken?: string
+    region?: string
+  }
+  return 'accessKeyId' in d && d.accessKeyId !== undefined
+    ? (d as { accessKeyId: string; secretAccessKey: string; sessionToken?: string; region: string })
+    : null
+})
+
+const awsProfileAuthData = computed(() => {
+  if (cluster.value.auth.authType !== AuthType.awsIAM) return null
+  const d = cluster.value.auth.authData as { awsCredentialType?: string; profileName?: string; region?: string }
+  return 'profileName' in d && d.profileName !== undefined ? (d as { profileName: string; region?: string }) : null
+})
+
+const awsCredentialType = computed({
+  get(): AwsCredentialType {
+    return getAwsCredentialType(cluster.value.auth) ?? 'basic'
+  },
+  set(value: AwsCredentialType) {
+    if (cluster.value.auth.authType !== AuthType.awsIAM) return
+    const prev = cluster.value.auth.authData as Record<string, unknown>
+    if (value === 'basic') {
+      cluster.value.auth.authData = {
+        awsCredentialType: 'basic',
+        accessKeyId: (prev.accessKeyId as string) ?? '',
+        secretAccessKey: (prev.secretAccessKey as string) ?? '',
+        sessionToken: (prev.sessionToken as string) ?? '',
+        region: (prev.region as string) ?? ''
+      }
+    } else {
+      cluster.value.auth.authData = {
+        awsCredentialType: 'profile',
+        profileName: (prev.profileName as string) ?? 'default',
+        region: (prev.region as string) ?? ''
+      }
+    }
+  }
+})
 
 const passwordVisible = ref(false)
-const t = useTranslation()
 const validateUri = (uri: string) => {
   try {
     new URL(uri)
@@ -166,4 +253,23 @@ const ssl = computed(() => /^https/.test(cluster.value.uri))
 
 const emit = defineEmits(['update:modelValue', 'update:formValid'])
 watch(cluster, (value) => emit('update:modelValue', value))
+
+// When switching to AWS IAM, ensure authData has the correct shape (basic by default)
+watch(
+  () => cluster.value.auth.authType,
+  (authType, prevType) => {
+    if (authType === AuthType.awsIAM && prevType !== AuthType.awsIAM) {
+      const data = cluster.value.auth.authData as Record<string, unknown>
+      if (!('accessKeyId' in data) && !('profileName' in data)) {
+        cluster.value.auth.authData = {
+          awsCredentialType: 'basic',
+          accessKeyId: '',
+          secretAccessKey: '',
+          sessionToken: '',
+          region: ''
+        }
+      }
+    }
+  }
+)
 </script>

--- a/src/composables/CallElasticsearch.ts
+++ b/src/composables/CallElasticsearch.ts
@@ -1,9 +1,10 @@
 import { computed, Ref, ref } from 'vue'
 import ElasticsearchAdapter, { ElasticsearchMethod } from '../services/ElasticsearchAdapter'
-import { useConnectionStore } from '../store/connection'
+import { AuthType, getAwsCredentialType, useConnectionStore } from '../store/connection'
 import { askConfirm } from '../helpers/dialogs'
 import { SnackbarOptions, useSnackbar } from './Snackbar'
 import { parseJson } from '../helpers/json/parse.ts'
+import { resolveConnectionForAdapter } from '../helpers/awsCredentials.ts'
 
 // Helper type to extract all parameters from a method
 type MethodParameters<T> = T extends (...args: infer P) => any ? P : never
@@ -19,6 +20,13 @@ type CallElasticsearchOverload = {
 }
 
 let elasticsearchAdapter: ElasticsearchAdapter
+
+const shouldRefreshAwsProfileCredentials = () => {
+  const connectionStore = useConnectionStore()
+  const cluster = connectionStore.activeCluster
+  if (!cluster || cluster.auth.authType !== AuthType.awsIAM) return false
+  return getAwsCredentialType(cluster.auth) === 'profile'
+}
 
 export interface RequestState {
   loading: boolean
@@ -49,15 +57,22 @@ export function useElasticsearchAdapter() {
     }
 
     try {
-      if (!elasticsearchAdapter) {
-        const cluster = connectionStore.activeCluster
-        if (!cluster) return
-        elasticsearchAdapter = new ElasticsearchAdapter(cluster)
+      const cluster = connectionStore.activeCluster
+      if (!cluster) return
+
+      let adapter = elasticsearchAdapter
+      if (shouldRefreshAwsProfileCredentials()) {
+        const resolved = await resolveConnectionForAdapter(cluster)
+        adapter = new ElasticsearchAdapter(resolved)
+      } else if (!elasticsearchAdapter) {
+        const resolved = await resolveConnectionForAdapter(cluster)
+        elasticsearchAdapter = new ElasticsearchAdapter(resolved)
         await elasticsearchAdapter.ping()
+        adapter = elasticsearchAdapter
       }
 
       try {
-        const response = await elasticsearchAdapter.call(method, ...args)
+        const response = await adapter.call(method, ...args)
         if (!response) return Promise.resolve()
 
         if (Array.isArray(response)) {
@@ -70,9 +85,9 @@ export function useElasticsearchAdapter() {
           }
           let result
           if (response.every((r: Response) => r.ok)) {
-            result = {acknowledged: true}
+            result = { acknowledged: true }
           } else {
-            result = {apiErrorMessage: 'Some requests failed.'}
+            result = { apiErrorMessage: 'Some requests failed.' }
           }
 
           return Promise.resolve(result)
@@ -121,16 +136,16 @@ export function useElasticsearchAdapter() {
           return Promise.reject(new Error('Request error'))
         }
       }
-    } catch (error) {
+    } catch (error: any) {
       requestState.value = {
         loading: false,
         networkError: true,
         apiError: false,
-        apiErrorMessage: '',
+        apiErrorMessage: error?.message ?? '',
         status: -1
       }
       console.error(error)
-      return Promise.reject(new Error('Error'))
+      return Promise.reject(error)
     }
   }
 

--- a/src/composables/ClusterConnection.ts
+++ b/src/composables/ClusterConnection.ts
@@ -1,5 +1,6 @@
 import { Ref, ref, UnwrapRef, useTemplateRef } from 'vue'
 import ElasticsearchAdapter from '../services/ElasticsearchAdapter'
+import { resolveConnectionForAdapter } from '../helpers/awsCredentials.ts'
 import { useTranslation } from './i18n'
 import { useSnackbar } from './Snackbar'
 import { BuildFlavor, ElasticsearchClusterConnection, useConnectionStore } from '../store/connection'
@@ -47,8 +48,9 @@ export const useClusterConnection = (
     resetState(connectState)
     testState.value.loading = true
 
-    const adapter = new ElasticsearchAdapter(formCluster.value)
     try {
+      const resolved = await resolveConnectionForAdapter(formCluster.value)
+      const adapter = new ElasticsearchAdapter(resolved)
       await adapter.test()
       testState.value.success = true
       testState.value.loading = false
@@ -59,10 +61,13 @@ export const useClusterConnection = (
       testState.value.success = false
       testState.value.error = true
       testState.value.loading = false
-      if (e.status && e.statusText) {
+      const msg = typeof e === 'string' ? e : e?.message
+      if (e?.status && e?.statusText) {
         testState.value.errorMessage = `${e.status} ${e.statusText}`
-      } else if (e.message) {
-        testState.value.errorMessage = e.message
+      } else if (msg?.includes('desktop app') || msg?.includes('desktop')) {
+        testState.value.errorMessage = t('setup.test_and_connect.form.aws_profile_desktop_only')
+      } else if (msg) {
+        testState.value.errorMessage = msg
       }
     }
   }
@@ -72,8 +77,9 @@ export const useClusterConnection = (
     resetState(connectState)
     connectState.value.loading = true
 
-    const adapter = new ElasticsearchAdapter(formCluster.value)
     try {
+      const resolved = await resolveConnectionForAdapter(formCluster.value)
+      const adapter = new ElasticsearchAdapter(resolved)
       const infoResponse: any = await adapter.test()
       const infoJson = await infoResponse.json()
 
@@ -113,10 +119,13 @@ export const useClusterConnection = (
       connectState.value.success = false
       connectState.value.error = true
       connectState.value.loading = false
-      if (e.status && e.statusText) {
+      const msg = typeof e === 'string' ? e : e?.message
+      if (e?.status && e?.statusText) {
         connectState.value.errorMessage = `${e.status} ${e.statusText}`
-      } else if (e.message) {
-        connectState.value.errorMessage = e.message
+      } else if (msg && (msg.includes('desktop app') || msg.includes('desktop'))) {
+        connectState.value.errorMessage = t('setup.test_and_connect.form.aws_profile_desktop_only')
+      } else if (msg) {
+        connectState.value.errorMessage = msg
       }
 
       return Promise.reject(e)

--- a/src/composables/components/home/ClusterHealth.ts
+++ b/src/composables/components/home/ClusterHealth.ts
@@ -5,6 +5,7 @@ import {
   useConnectionStore
 } from '../../../store/connection.ts'
 import ElasticsearchAdapter from '../../../services/ElasticsearchAdapter.ts'
+import { resolveConnectionForAdapter } from '../../../helpers/awsCredentials.ts'
 import { clusterUuid } from '../../ClusterConnection.ts'
 import { DISTRIBUTIONS } from '../../../consts.ts'
 
@@ -29,7 +30,15 @@ export const useClusterHealth = () => {
 
 export const checkHealth = async (cluster: ElasticsearchCluster) => {
   cluster.loading = true
-  const adapter = new ElasticsearchAdapter(cluster)
+  let adapter: ElasticsearchAdapter
+  try {
+    const resolved = await resolveConnectionForAdapter(cluster)
+    adapter = new ElasticsearchAdapter(resolved)
+  } catch (_e) {
+    cluster.status = 'unknown'
+    cluster.loading = false
+    return
+  }
 
   try {
     const pingResponse: any = await adapter.ping()
@@ -62,7 +71,13 @@ export const checkHealth = async (cluster: ElasticsearchCluster) => {
 }
 
 export const checkClusterHealth = async (credentials: ElasticsearchClusterConnection): Promise<string> => {
-  const adapter = new ElasticsearchAdapter(credentials)
+  let adapter: ElasticsearchAdapter
+  try {
+    const resolved = await resolveConnectionForAdapter(credentials)
+    adapter = new ElasticsearchAdapter(resolved)
+  } catch (_e) {
+    return 'unknown'
+  }
 
   try {
     const clusterHealthResponse: any = await adapter.clusterHealth()

--- a/src/composables/components/indices/ClusterIndices.ts
+++ b/src/composables/components/indices/ClusterIndices.ts
@@ -29,10 +29,10 @@ export const useClusterIndices = () => {
 
   const load = async () => {
     try {
-      const [indices, aliasesData] = await Promise.all([
+      const [indices, aliasesData] = (await Promise.all([
         callElasticsearch('catIndices', CAT_INDICES_PARAMS),
         callElasticsearch('indexGetAlias', { index: '*' })
-      ]) as [EsIndex[], IndexGetAliasResponse]
+      ])) as [EsIndex[], IndexGetAliasResponse]
 
       indices.forEach((index: EsIndex) => {
         if (aliasesData[index.index] && aliasesData[index.index].aliases) {

--- a/src/helpers/awsCredentials.ts
+++ b/src/helpers/awsCredentials.ts
@@ -1,0 +1,63 @@
+import { invoke } from '@tauri-apps/api/core'
+import { buildConfig } from '../buildConfig.ts'
+import { AuthType, type ElasticsearchClusterConnection, getAwsCredentialType } from '../store/connection.ts'
+
+type ResolvedAwsCredentials = {
+  accessKeyId: string
+  secretAccessKey: string
+  sessionToken?: string
+  region: string
+}
+
+/**
+ * Resolves AWS profile to explicit credentials via Tauri (desktop only).
+ * Returns the connection unchanged for non-AWS or basic credentials.
+ */
+export async function resolveConnectionForAdapter(
+  connection: ElasticsearchClusterConnection
+): Promise<ElasticsearchClusterConnection> {
+  if (connection.auth.authType !== AuthType.awsIAM) {
+    return connection
+  }
+  const credentialType = getAwsCredentialType(connection.auth)
+  if (credentialType !== 'profile') {
+    return connection
+  }
+
+  const data = connection.auth.authData
+  if (data.awsCredentialType !== 'profile') {
+    return connection
+  }
+
+  const { profileName, region: profileRegion } = data
+
+  if (!buildConfig.tauri) {
+    return Promise.reject(new Error('AWS Profile is only available in the desktop app.'))
+  }
+
+  let result: ResolvedAwsCredentials
+  try {
+    result = await invoke<ResolvedAwsCredentials>('resolve_aws_profile', {
+      // Tauri maps Rust `profile_name` to JS `profileName` by default
+      profileName: profileName || 'default',
+      region: profileRegion || undefined
+    })
+  } catch (err: unknown) {
+    const msg = typeof err === 'string' ? err : (err as Error)?.message ?? 'Failed to resolve AWS profile'
+    return Promise.reject(new Error(msg))
+  }
+
+  return {
+    ...connection,
+    auth: {
+      authType: AuthType.awsIAM,
+      authData: {
+        awsCredentialType: 'basic' as const,
+        accessKeyId: result.accessKeyId,
+        secretAccessKey: result.secretAccessKey,
+        sessionToken: result.sessionToken,
+        region: result.region
+      }
+    }
+  }
+}

--- a/src/helpers/predefinedClusters/buildAuth.ts
+++ b/src/helpers/predefinedClusters/buildAuth.ts
@@ -29,6 +29,7 @@ export const buildAuth = (cluster: PredefinedCluster): ElasticsearchClusterAuth 
     return {
       authType: AuthType.awsIAM,
       authData: {
+        awsCredentialType: 'basic' as const,
         accessKeyId: S3accessKeyId,
         secretAccessKey: S3secretAccessKey,
         sessionToken: S3sessionToken,

--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -551,6 +551,18 @@
         "uri": {
           "label": "地址"
         },
+        "aws_credential_type": {
+          "label": "凭证类型",
+          "basic": "基本凭证",
+          "profile": "AWS 配置文件"
+        },
+        "profile_name": {
+          "label": "配置文件名称"
+        },
+        "region_optional": {
+          "label": "区域（可选）"
+        },
+        "aws_profile_desktop_only": "AWS 配置文件仅在桌面应用中可用。",
         "access_key_id": {
           "label": "访问密钥 ID"
         },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -569,6 +569,18 @@
         "uri": {
           "label": "Uri"
         },
+        "aws_credential_type": {
+          "label": "Credential type",
+          "basic": "Basic Credentials",
+          "profile": "AWS Profile"
+        },
+        "profile_name": {
+          "label": "Profile name"
+        },
+        "region_optional": {
+          "label": "Region (optional)"
+        },
+        "aws_profile_desktop_only": "AWS Profile is only available in the desktop app.",
         "access_key_id": {
           "label": "Access key ID"
         },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -551,6 +551,18 @@
         "uri": {
           "label": "Uri"
         },
+        "aws_credential_type": {
+          "label": "Type d'identifiants",
+          "basic": "Identifiants de base",
+          "profile": "Profil AWS"
+        },
+        "profile_name": {
+          "label": "Nom du profil"
+        },
+        "region_optional": {
+          "label": "Région (optionnel)"
+        },
+        "aws_profile_desktop_only": "Le profil AWS n'est disponible que dans l'application bureau.",
         "access_key_id": {
           "label": "ID de clé d'accès"
         },

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -551,6 +551,18 @@
         "uri": {
           "label": "Uri"
         },
+        "aws_credential_type": {
+          "label": "Tipo di credenziali",
+          "basic": "Credenziali di base",
+          "profile": "Profilo AWS"
+        },
+        "profile_name": {
+          "label": "Nome profilo"
+        },
+        "region_optional": {
+          "label": "Regione (opzionale)"
+        },
+        "aws_profile_desktop_only": "Il profilo AWS è disponibile solo nell'app desktop.",
         "access_key_id": {
           "label": "ID chiave di accesso"
         },

--- a/src/locales/jp.json
+++ b/src/locales/jp.json
@@ -551,6 +551,18 @@
         "uri": {
           "label": "URI"
         },
+        "aws_credential_type": {
+          "label": "認証情報の種類",
+          "basic": "基本認証情報",
+          "profile": "AWSプロファイル"
+        },
+        "profile_name": {
+          "label": "プロファイル名"
+        },
+        "region_optional": {
+          "label": "リージョン（任意）"
+        },
+        "aws_profile_desktop_only": "AWSプロファイルはデスクトップアプリでのみ利用できます。",
         "access_key_id": {
           "label": "アクセスキー ID"
         },

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -551,6 +551,18 @@
         "uri": {
           "label": "URI"
         },
+        "aws_credential_type": {
+          "label": "자격 증명 유형",
+          "basic": "기본 자격 증명",
+          "profile": "AWS 프로필"
+        },
+        "profile_name": {
+          "label": "프로필 이름"
+        },
+        "region_optional": {
+          "label": "리전(선택 사항)"
+        },
+        "aws_profile_desktop_only": "AWS 프로필은 데스크톱 앱에서만 사용할 수 있습니다.",
         "access_key_id": {
           "label": "액세스 키 ID"
         },

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -551,6 +551,18 @@
         "uri": {
           "label": "URI"
         },
+        "aws_credential_type": {
+          "label": "Тип учётных данных",
+          "basic": "Базовые учётные данные",
+          "profile": "Профиль AWS"
+        },
+        "profile_name": {
+          "label": "Имя профиля"
+        },
+        "region_optional": {
+          "label": "Регион (необязательно)"
+        },
+        "aws_profile_desktop_only": "Профиль AWS доступен только в настольном приложении.",
         "access_key_id": {
           "label": "ID ключа доступа"
         },

--- a/src/locales/tw.json
+++ b/src/locales/tw.json
@@ -551,6 +551,18 @@
         "uri": {
           "label": "URI"
         },
+        "aws_credential_type": {
+          "label": "憑證類型",
+          "basic": "基本憑證",
+          "profile": "AWS 設定檔"
+        },
+        "profile_name": {
+          "label": "設定檔名稱"
+        },
+        "region_optional": {
+          "label": "區域（選填）"
+        },
+        "aws_profile_desktop_only": "AWS 設定檔僅在桌面應用程式中可用。",
         "access_key_id": {
           "label": "存取金鑰 ID"
         },

--- a/src/services/ElasticsearchAdapter.ts
+++ b/src/services/ElasticsearchAdapter.ts
@@ -25,12 +25,13 @@ export default class ElasticsearchAdapter {
   constructor({ uri, auth }: ElasticsearchClusterConnection) {
     this.uri = addTrailingSlash(uri)
 
-    if (auth.authType === AuthType.awsIAM) {
+    if (auth.authType === AuthType.awsIAM && 'accessKeyId' in auth.authData) {
+      const data = auth.authData
       this.awsClient = new AwsClient({
-        accessKeyId: auth.authData.accessKeyId,
-        secretAccessKey: auth.authData.secretAccessKey,
-        sessionToken: auth.authData.sessionToken,
-        region: auth.authData.region,
+        accessKeyId: data.accessKeyId,
+        secretAccessKey: data.secretAccessKey,
+        sessionToken: data.sessionToken,
+        region: data.region,
         service: 'es'
       })
     }

--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -45,8 +45,28 @@ export type ElasticsearchClusterAuth =
     }
   | {
       authType: AuthType.awsIAM
-      authData: { accessKeyId: string; secretAccessKey: string; sessionToken?: string; region: string }
+      authData:
+        | {
+            awsCredentialType: 'basic'
+            accessKeyId: string
+            secretAccessKey: string
+            sessionToken?: string
+            region: string
+          }
+        | {
+            awsCredentialType: 'profile'
+            profileName: string
+            region?: string
+          }
     }
+
+export type AwsCredentialType = 'basic' | 'profile'
+
+export function getAwsCredentialType(auth: ElasticsearchClusterAuth): AwsCredentialType | null {
+  if (auth.authType !== AuthType.awsIAM) return null
+  const data = auth.authData as { awsCredentialType?: AwsCredentialType }
+  return data.awsCredentialType === 'profile' ? 'profile' : 'basic'
+}
 
 export type ConnectionState = {
   clusters: ElasticsearchCluster[]
@@ -140,18 +160,35 @@ const cleanupClusterAuth = (cluster: ElasticsearchCluster): ElasticsearchCluster
           }
         }
       }
-    case AuthType.awsIAM:
+    case AuthType.awsIAM: {
+      const data = cluster.auth.authData as {
+        awsCredentialType?: AwsCredentialType
+        accessKeyId?: string
+        secretAccessKey?: string
+        sessionToken?: string
+        region?: string
+        profileName?: string
+      }
+      const isProfile = data.awsCredentialType === 'profile'
       return {
         ...cluster,
         auth: {
           authType: AuthType.awsIAM,
-          authData: {
-            accessKeyId: cluster.auth.authData.accessKeyId,
-            secretAccessKey: cluster.auth.authData.secretAccessKey,
-            sessionToken: cluster.auth.authData.sessionToken,
-            region: cluster.auth.authData.region
-          }
+          authData: isProfile
+            ? {
+                awsCredentialType: 'profile' as const,
+                profileName: data.profileName ?? '',
+                region: data.region
+              }
+            : {
+                awsCredentialType: 'basic' as const,
+                accessKeyId: data.accessKeyId ?? '',
+                secretAccessKey: data.secretAccessKey ?? '',
+                sessionToken: data.sessionToken,
+                region: data.region ?? ''
+              }
         }
       }
+    }
   }
 }

--- a/tests/unit/composables/CallElasticsearch.spec.ts
+++ b/tests/unit/composables/CallElasticsearch.spec.ts
@@ -1,16 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
-import { AuthType, BuildFlavor, useConnectionStore, type ElasticsearchCluster } from '../../../src/store/connection'
+import {
+  AuthType,
+  BuildFlavor,
+  useConnectionStore,
+  type ElasticsearchCluster,
+  type ElasticsearchClusterConnection
+} from '../../../src/store/connection'
 import { useElasticsearchAdapter } from '../../../src/composables/CallElasticsearch'
+import type { ElasticsearchMethod } from '../../../src/services/ElasticsearchAdapter'
 
 const { adapterCallMock, adapterPingMock, adapterConstructorMock, resolveConnectionForAdapterMock } = vi.hoisted(() => {
   const adapterCall = vi.fn().mockResolvedValue(undefined)
   const adapterPing = vi.fn().mockResolvedValue(undefined)
-  const adapterConstructor = vi.fn(function (this: any) {
+  const adapterConstructor = vi.fn(function (this: { call: Mock; ping: Mock }) {
     this.call = adapterCall
     this.ping = adapterPing
   })
-  const resolveConnectionForAdapter = vi.fn(async (connection: any) => connection)
+  const resolveConnectionForAdapter = vi.fn(async (connection: ElasticsearchClusterConnection) => connection)
   return {
     adapterCallMock: adapterCall,
     adapterPingMock: adapterPing,
@@ -40,6 +48,8 @@ const createCluster = (auth: ElasticsearchCluster['auth']): ElasticsearchCluster
   auth
 })
 
+const pingMethod: ElasticsearchMethod = 'ping'
+
 describe('CallElasticsearch', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -63,8 +73,8 @@ describe('CallElasticsearch', () => {
     store.activeClusterIndex = 0
 
     const { callElasticsearch } = useElasticsearchAdapter()
-    await callElasticsearch('ping' as any)
-    await callElasticsearch('ping' as any)
+    await callElasticsearch(pingMethod)
+    await callElasticsearch(pingMethod)
 
     expect(resolveConnectionForAdapterMock).toHaveBeenCalledTimes(2)
     expect(adapterConstructorMock).toHaveBeenCalledTimes(2)
@@ -87,8 +97,8 @@ describe('CallElasticsearch', () => {
     store.activeClusterIndex = 0
 
     const { callElasticsearch } = useElasticsearchAdapter()
-    await callElasticsearch('ping' as any)
-    await callElasticsearch('ping' as any)
+    await callElasticsearch(pingMethod)
+    await callElasticsearch(pingMethod)
 
     expect(resolveConnectionForAdapterMock).toHaveBeenCalledTimes(1)
     expect(adapterConstructorMock).toHaveBeenCalledTimes(1)

--- a/tests/unit/composables/CallElasticsearch.spec.ts
+++ b/tests/unit/composables/CallElasticsearch.spec.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { AuthType, BuildFlavor, useConnectionStore, type ElasticsearchCluster } from '../../../src/store/connection'
+import { useElasticsearchAdapter } from '../../../src/composables/CallElasticsearch'
+
+const { adapterCallMock, adapterPingMock, adapterConstructorMock, resolveConnectionForAdapterMock } = vi.hoisted(() => {
+  const adapterCall = vi.fn().mockResolvedValue(undefined)
+  const adapterPing = vi.fn().mockResolvedValue(undefined)
+  const adapterConstructor = vi.fn(function (this: any) {
+    this.call = adapterCall
+    this.ping = adapterPing
+  })
+  const resolveConnectionForAdapter = vi.fn(async (connection: any) => connection)
+  return {
+    adapterCallMock: adapterCall,
+    adapterPingMock: adapterPing,
+    adapterConstructorMock: adapterConstructor,
+    resolveConnectionForAdapterMock: resolveConnectionForAdapter
+  }
+})
+
+vi.mock('../../../src/services/ElasticsearchAdapter', () => ({
+  default: adapterConstructorMock
+}))
+
+vi.mock('../../../src/helpers/awsCredentials.ts', () => ({
+  resolveConnectionForAdapter: resolveConnectionForAdapterMock
+}))
+
+const createCluster = (auth: ElasticsearchCluster['auth']): ElasticsearchCluster => ({
+  clusterName: 'cluster',
+  version: '8.0.0',
+  majorVersion: '8',
+  distribution: 'elasticsearch',
+  uuid: 'uuid',
+  status: 'green',
+  flavor: BuildFlavor.default,
+  name: 'cluster',
+  uri: 'http://localhost:9200',
+  auth
+})
+
+describe('CallElasticsearch', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    adapterCallMock.mockClear()
+    adapterPingMock.mockClear()
+    adapterConstructorMock.mockClear()
+    resolveConnectionForAdapterMock.mockClear()
+  })
+
+  it('re-resolves profile credentials for each request', async () => {
+    const store = useConnectionStore()
+    store.clusters = [
+      createCluster({
+        authType: AuthType.awsIAM,
+        authData: {
+          awsCredentialType: 'profile',
+          profileName: 'default'
+        }
+      })
+    ]
+    store.activeClusterIndex = 0
+
+    const { callElasticsearch } = useElasticsearchAdapter()
+    await callElasticsearch('ping' as any)
+    await callElasticsearch('ping' as any)
+
+    expect(resolveConnectionForAdapterMock).toHaveBeenCalledTimes(2)
+    expect(adapterConstructorMock).toHaveBeenCalledTimes(2)
+    expect(adapterPingMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps singleton adapter behavior for non-profile auth', async () => {
+    const store = useConnectionStore()
+    store.clusters = [
+      createCluster({
+        authType: AuthType.awsIAM,
+        authData: {
+          awsCredentialType: 'basic',
+          accessKeyId: 'AKIA',
+          secretAccessKey: 'SECRET',
+          region: 'eu-west-1'
+        }
+      })
+    ]
+    store.activeClusterIndex = 0
+
+    const { callElasticsearch } = useElasticsearchAdapter()
+    await callElasticsearch('ping' as any)
+    await callElasticsearch('ping' as any)
+
+    expect(resolveConnectionForAdapterMock).toHaveBeenCalledTimes(1)
+    expect(adapterConstructorMock).toHaveBeenCalledTimes(1)
+    expect(adapterPingMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/helpers/predefinedClusters/buildAuth.spec.ts
+++ b/tests/unit/helpers/predefinedClusters/buildAuth.spec.ts
@@ -58,6 +58,7 @@ describe('buildAuth', () => {
       authType: AuthType.awsIAM,
       authData: {
         accessKeyId: 'AKIA123',
+        awsCredentialType: 'basic',
         secretAccessKey: 'SECRET',
         region: 'us-west-1',
         sessionToken: 'SESSION'


### PR DESCRIPTION
Adds a bit of new UI to the AWS IAM bit under edit cluster so we have credential type; which allows me to cram in a profile flag.
I've avoided adding aws sdk by simply relying on where AWS stores its config files and how profiles and apps like leapp tend to work with sso.

<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/61dbc78d-7b31-49d0-a7b2-3093a07897cb" />
<img width="782" height="276" alt="image" src="https://github.com/user-attachments/assets/b27d7cef-459f-4b72-8c9a-ec8817a5e669" />
<img width="804" height="774" alt="image" src="https://github.com/user-attachments/assets/c6e6fc21-0a7e-4b48-a62c-1e6ec45d95de" />
